### PR TITLE
データベースに中間テーブルを作る

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
-# README
+## groups_usersテーブル
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
#What
中間テーブルを作るためREADME.mdにテーブル名、カラム名、カラムの型、カラムのオプション（null false制約など）、アソシエーションを記述

#Why
中間テーブルがないと多対多が解決できないため
